### PR TITLE
Fix NPE in processTrackQueue when chunk data is null

### DIFF
--- a/shreddedpaper-server/src/main/java/io/multipaper/shreddedpaper/threading/ShreddedPaperEntityTicker.java
+++ b/shreddedpaper-server/src/main/java/io/multipaper/shreddedpaper/threading/ShreddedPaperEntityTicker.java
@@ -41,6 +41,7 @@ public class ShreddedPaperEntityTicker {
     /** processTrackQueue has been renamed to newTrackerTick */
     public static void processTrackQueue(Entity entity) {
         ChunkMap.TrackedEntity tracker = Objects.requireNonNull(entity.moonrise$getTrackedEntity());
+        if (((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity)entity).moonrise$getChunkData() == null) return; // ShreddedPaper - skip if chunk data not loaded
         ((ca.spottedleaf.moonrise.patches.entity_tracker.EntityTrackerTrackedEntity)tracker).moonrise$tick(((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity)entity).moonrise$getChunkData().nearbyPlayers);
         if (((ca.spottedleaf.moonrise.patches.entity_tracker.EntityTrackerTrackedEntity)tracker).moonrise$hasPlayers()
                 || ((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity)entity).moonrise$getChunkStatus().isOrAfter(FullChunkStatus.ENTITY_TICKING)) {


### PR DESCRIPTION
Fixes the following crash:
```
---- Minecraft Crash Report ----
// Oops.
// 
// DO NOT REPORT THIS TO PAPER! REPORT TO SHREDDEDPAPER INSTEAD!
// 

Time: 2026-01-09 01:30:31
Description: Exception in server tick loop

java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot read field "nearbyPlayers" because the return value of "ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity.moonrise$getChunkData()" is null
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1807)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NullPointerException: Cannot read field "nearbyPlayers" because the return value of "ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity.moonrise$getChunkData()" is null
	at io.multipaper.shreddedpaper.threading.ShreddedPaperEntityTicker.processTrackQueue(ShreddedPaperEntityTicker.java:44)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at io.multipaper.shreddedpaper.threading.ShreddedPaperChunkTicker.lambda$processTrackQueueInParallel$6(ShreddedPaperChunkTicker.java:71)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	... 3 more
```