### PR TITLE
Fix cross-region teleportation in SpreadPlayersCommand

### DIFF
--- a/shreddedpaper-server/minecraft-patches/sources/net/minecraft/server/commands/SpreadPlayersCommand.java.patch
+++ b/shreddedpaper-server/minecraft-patches/sources/net/minecraft/server/commands/SpreadPlayersCommand.java.patch
@@ -1,6 +1,23 @@
 --- a/net/minecraft/server/commands/SpreadPlayersCommand.java
 +++ b/net/minecraft/server/commands/SpreadPlayersCommand.java
-@@ -246,17 +_,12 @@
+@@ -30,6 +_,7 @@
+ import net.minecraft.world.level.block.state.BlockState;
+ import net.minecraft.world.phys.Vec2;
+ import net.minecraft.world.scores.Team;
++import io.multipaper.shreddedpaper.ShreddedPaper;
+ 
+ public class SpreadPlayersCommand {
+     private static final int MAX_ITERATION_COUNT = 10000;
+@@ -205,6 +_,8 @@
+ 
+             if (!flag) {
+                 for (SpreadPlayersCommand.Position position1 : positions) {
++                    // ShreddedPaper - isSafe does read-only block access; blocking to sync would cause deadlock
++                    // when command runs on a region thread, so we accept the minor race condition here
+                     if (!position1.isSafe(level, maxHeight)) {
+                         position1.randomize(random, minX, minZ, maxX, maxZ);
+                         flag = true;
+@@ -246,17 +_,19 @@
                  position = positions[i++];
              }
  
@@ -14,12 +31,20 @@
 -                entity.getXRot(),
 -                true
 -                , org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND // CraftBukkit - handle teleport reason
-+            // ShreddedPaper start - use teleportAsync to handle cross-region teleportation
-+            entity.getBukkitEntity().teleportAsync(
-+                new org.bukkit.Location(level.getWorld(), Mth.floor(position.x) + 0.5, position.getSpawnY(level, maxHeight), Mth.floor(position.z) + 0.5, entity.getYRot(), entity.getXRot()),
-+                org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND
-             );
-+            // ShreddedPaper end - use teleportAsync to handle cross-region teleportation
+-            );
++            // ShreddedPaper start - compute spawn Y on correct region thread, then teleport
++            final float entityYRot = entity.getYRot();
++            final float entityXRot = entity.getXRot();
++            final SpreadPlayersCommand.Position finalPosition = position;
++            BlockPos targetPos = BlockPos.containing(position.x, maxHeight, position.z);
++            ShreddedPaper.runSync(level, targetPos, () -> {
++                int spawnY = finalPosition.getSpawnY(level, maxHeight);
++                entity.getBukkitEntity().teleportAsync(
++                    new org.bukkit.Location(level.getWorld(), Mth.floor(finalPosition.x) + 0.5, spawnY, Mth.floor(finalPosition.z) + 0.5, entityYRot, entityXRot),
++                    org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND
++                );
++            });
++            // ShreddedPaper end - compute spawn Y on correct region thread, then teleport
              double d1 = Double.MAX_VALUE;
  
              for (SpreadPlayersCommand.Position position1 : positions) {

--- a/shreddedpaper-server/minecraft-patches/sources/net/minecraft/server/commands/SpreadPlayersCommand.java.patch
+++ b/shreddedpaper-server/minecraft-patches/sources/net/minecraft/server/commands/SpreadPlayersCommand.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/server/commands/SpreadPlayersCommand.java
++++ b/net/minecraft/server/commands/SpreadPlayersCommand.java
+@@ -246,17 +_,12 @@
+                 position = positions[i++];
+             }
+ 
+-            entity.teleportTo(
+-                level,
+-                Mth.floor(position.x) + 0.5,
+-                position.getSpawnY(level, maxHeight),
+-                Mth.floor(position.z) + 0.5,
+-                Set.of(),
+-                entity.getYRot(),
+-                entity.getXRot(),
+-                true
+-                , org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND // CraftBukkit - handle teleport reason
++            // ShreddedPaper start - use teleportAsync to handle cross-region teleportation
++            entity.getBukkitEntity().teleportAsync(
++                new org.bukkit.Location(level.getWorld(), Mth.floor(position.x) + 0.5, position.getSpawnY(level, maxHeight), Mth.floor(position.z) + 0.5, entity.getYRot(), entity.getXRot()),
++                org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND
+             );
++            // ShreddedPaper end - use teleportAsync to handle cross-region teleportation
+             double d1 = Double.MAX_VALUE;
+ 
+             for (SpreadPlayersCommand.Position position1 : positions) {


### PR DESCRIPTION
## Summary
- Fixes "Cannot move entity off-main" error when using `/spreadplayers` command
- Uses `teleportAsync` instead of synchronous `teleportTo` to properly handle cross-region teleportation

## Problem
The `/spreadplayers` command was causing thread errors because it attempted to teleport entities synchronously to random positions that could be in different regions than the current thread owns. This resulted in moonrise thread check failures during the position update.

## Solution
Replaced the synchronous `entity.teleportTo()` call with `entity.getBukkitEntity().teleportAsync()`, which schedules the teleport on the entity's task scheduler. This ensures the teleport executes when the entity is being ticked by the appropriate thread that owns both the source and destination regions.

## Test plan
- [x] Build compiles successfully
- [x] Unit tests pass
- [x] Manual testing: `/spreadplayers ~ ~ 5 1000 false @a` executes without errors