### PR TITLE
Fix Folia support detection for paper plugins

### DIFF
--- a/shreddedpaper-api/paper-patches/files/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java.patch
+++ b/shreddedpaper-api/paper-patches/files/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java.patch
@@ -1,0 +1,9 @@
+--- a/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
++++ b/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
+@@ -189,4 +_,6 @@
+     default String namespace() {
+         return this.getName().toLowerCase(Locale.ROOT);
+     }
++
++    boolean isFoliaSupported(); // ShreddedPaper - Folia supported
+ }

--- a/shreddedpaper-api/paper-patches/files/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java.patch
+++ b/shreddedpaper-api/paper-patches/files/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java.patch
@@ -4,17 +4,34 @@
      private Set<PluginAwareness> awareness = ImmutableSet.of();
      private String apiVersion = null;
      private List<String> libraries = ImmutableList.of();
-+    private String foliaSupported = null; // ShreddedPaper
++    private Boolean foliaSupported = null; // ShreddedPaper
      // Paper start - plugin loader api
      private String paperPluginLoader;
      @org.jetbrains.annotations.ApiStatus.Internal @org.jetbrains.annotations.Nullable
+@@ -272,7 +_,7 @@
+      * @hidden
+      */
+     @org.jetbrains.annotations.ApiStatus.Internal
+-    public PluginDescriptionFile(String rawName, String name, List<String> provides, String main, String classLoaderOf, List<String> depend, List<String> softDepend, List<String> loadBefore, String version, Map<String, Map<String, Object>> commands, String description, List<String> authors, List<String> contributors, String website, String prefix, PluginLoadOrder order, List<Permission> permissions, PermissionDefault defaultPerm, Set<PluginAwareness> awareness, String apiVersion, List<String> libraries) {
++    public PluginDescriptionFile(String rawName, String name, List<String> provides, String main, String classLoaderOf, List<String> depend, List<String> softDepend, List<String> loadBefore, String version, Map<String, Map<String, Object>> commands, String description, List<String> authors, List<String> contributors, String website, String prefix, PluginLoadOrder order, List<Permission> permissions, PermissionDefault defaultPerm, Set<PluginAwareness> awareness, String apiVersion, List<String> libraries, boolean foliaSupported) { // ShreddedPaper - Folia supported
+         this.rawName = rawName;
+         this.name = name;
+         this.provides = provides;
+@@ -294,6 +_,7 @@
+         this.awareness = awareness;
+         this.apiVersion = apiVersion;
+         this.libraries = libraries;
++        this.foliaSupported = foliaSupported; // ShreddedPaper - Folia supported
+     }
+ 
+     @Override
 @@ -1057,6 +_,11 @@
          return libraries;
      }
  
 +    // ShreddedPaper start
 +    public boolean isFoliaSupported() {
-+        return "true".equalsIgnoreCase(foliaSupported);
++        return Boolean.TRUE.equals(foliaSupported);
 +    }
 +
      /**
@@ -26,7 +43,7 @@
  
 +        // ShreddedPaper start
 +        if (map.get("folia-supported") != null) {
-+            foliaSupported = map.get("folia-supported").toString();
++            foliaSupported = Boolean.parseBoolean(map.get("folia-supported").toString());
 +        }
 +        // ShreddedPaper end
 +
@@ -40,7 +57,7 @@
 +
 +        // ShreddedPaper start
 +        if (foliaSupported != null) {
-+            map.put("folia-supported", foliaSupported);
++            map.put("folia-supported", foliaSupported.toString());
 +        }
 +        // ShreddedPaper end
  

--- a/shreddedpaper-server/paper-patches/files/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java.patch
+++ b/shreddedpaper-server/paper-patches/files/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java.patch
@@ -1,0 +1,12 @@
+--- a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
++++ b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
+@@ -170,7 +_,8 @@
+             config.getPermissionDefault(),
+             Set.of(), // Aware api
+             config.getAPIVersion(),
+-            List.of() // Libraries
++            List.of(), // Libraries
++            config.isFoliaSupported() // ShreddedPaper - Folia supported
+         );
+ 
+         File dataFolder = new File(Bukkit.getPluginsFolder(), pluginDescriptionFile.getName());

--- a/shreddedpaper-server/paper-patches/files/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java.patch
+++ b/shreddedpaper-server/paper-patches/files/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java.patch
@@ -1,0 +1,17 @@
+--- a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
++++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
+@@ -64,6 +_,7 @@
+     private PermissionConfiguration permissionConfiguration = new PermissionConfiguration(PermissionDefault.OP, List.of());
+     @Required
+     private ApiVersion apiVersion;
++    private boolean foliaSupported = false; // ShreddedPaper - Folia supported
+ 
+     private Map<PluginDependencyLifeCycle, Map<String, DependencyConfiguration>> dependencies = new EnumMap<>(PluginDependencyLifeCycle.class);
+ 
+@@ -267,5 +_,5 @@
+     public boolean hasOpenClassloader() {
+         return this.hasOpenClassloader;
+     }
+-
++    @Override public boolean isFoliaSupported() { return foliaSupported; } // ShreddedPaper - Folia supported
+ }

--- a/shreddedpaper-server/paper-patches/files/src/test/java/io/papermc/paper/plugin/TestPluginMeta.java.patch
+++ b/shreddedpaper-server/paper-patches/files/src/test/java/io/papermc/paper/plugin/TestPluginMeta.java.patch
@@ -1,0 +1,8 @@
+--- a/src/test/java/io/papermc/paper/plugin/TestPluginMeta.java
++++ b/src/test/java/io/papermc/paper/plugin/TestPluginMeta.java
+@@ -111,4 +_,5 @@
+     public @NotNull String getAPIVersion() {
+         return "null";
+     }
++    @Override public boolean isFoliaSupported() { return false; } // ShreddedPaper - Folia supported
+ }

--- a/shreddedpaper-server/src/main/java/io/multipaper/shreddedpaper/threading/SynchronousPluginExecution.java
+++ b/shreddedpaper-server/src/main/java/io/multipaper/shreddedpaper/threading/SynchronousPluginExecution.java
@@ -44,7 +44,7 @@ public class SynchronousPluginExecution {
 
     public static void execute(Plugin plugin, RunnableWithException runnable) throws Exception {
         ShreddedPaperConfiguration config = ShreddedPaperConfiguration.get();
-        if (plugin == null || config == null || !config.multithreading.runUnsupportedPluginsInSync || plugin.getDescription().isFoliaSupported() || TickThread.isShutdownThread()) {
+        if (plugin == null || config == null || !config.multithreading.runUnsupportedPluginsInSync || plugin.getPluginMeta().isFoliaSupported() || TickThread.isShutdownThread()) {
             // Multi-thread safe plugin, run it straight away
             runnable.run();
             return;
@@ -140,7 +140,7 @@ public class SynchronousPluginExecution {
     }
 
     private static boolean fillPluginsToLock(Plugin plugin, TreeSet<String> pluginsToLock, List<String> parentList) {
-        if (plugin.getDescription().isFoliaSupported()) {
+        if (plugin.getPluginMeta().isFoliaSupported()) {
             // Multi-thread safe plugin, we don't need to lock it
             return false;
         }


### PR DESCRIPTION
Previously, plugins using the new `paper-plugin.yml` format were not detected as Folia-compatible, even when they explicitly declared Folia support.

This caused those plugins to be treated as unsupported and potentially forced into synchronous execution.

This PR fixes the detection by exposing `isFoliaSupported()` through `PluginMeta` and using the plugin metadata directly when checking whether a plugin supports Folia. It also forwards the `folia-supported` value from `PaperPluginMeta` into the generated `PluginDescriptionFile`, keeping support checks consistent for both legacy and modern plugin metadata.
