### PR TITLE
Fix #49: synchronize Connection.flushQueue against concurrent region threads

### DIFF
--- a/shreddedpaper-server/minecraft-patches/sources/net/minecraft/network/Connection.java.patch
+++ b/shreddedpaper-server/minecraft-patches/sources/net/minecraft/network/Connection.java.patch
@@ -62,7 +62,7 @@
              this.channel.eventLoop().execute(() -> this.doSendPacket(packet, listener, flush));
          }
      }
-@@ -499,7 +_,7 @@
+@@ -499,19 +_,18 @@
      }
  
      // Paper start - Optimize network: Rewrite this to be safer if ran off main thread
@@ -71,6 +71,24 @@
          if (!this.isConnected()) {
              return true;
          }
+-        if (io.papermc.paper.util.MCUtil.isMainThread()) {
++        // ShreddedPaper start - Fix packet order: every ShreddedPaperTickThread satisfies isMainThread(), so unlike
++        // vanilla's single main thread, multiple region-tick-pool threads can reach flushQueue() for the same
++        // connection at once (tick(), send() from an async plugin call, and flushQueueInParallel's own sweep all
++        // race). Always synchronize so pendingActions is only ever drained by one thread at a time.
++        synchronized (this.pendingActions) {
+             return this.processQueue();
+-        } else if (this.isPending) {
+-            // Should only happen during login/status stages
+-            synchronized (this.pendingActions) {
+-                return this.processQueue();
+-            }
+         }
+-        return false;
++        // ShreddedPaper end - Fix packet order
+     }
+ 
+     private boolean processQueue() {
 @@ -555,7 +_,8 @@
      private static int currTick; // Paper - Buffer joins to world
      private static int tickSecond; // Purpur - Max joins per second


### PR DESCRIPTION
## Summary

Fixes #49. Traced the root cause: `ShreddedPaperTickThread extends TickThread`, so every region-tick-pool thread satisfies Paper's `isMainThread()` check (`MCUtil.isMainThread()` delegates to `MinecraftServer.isSameThread()`, which is patched to `TickThread.isTickThread()`).

Paper's original `flushQueue()` skips synchronization on the `isMainThread()` path, an assumption that's safe in vanilla (only one thread is ever "main") but broken here: a player's `flushQueue()` can be reached concurrently from
- `Connection.tick()` on the region thread that owns the player,
- `send()` called from an async plugin task on some other thread,
- `flushQueueInParallel()`'s own sweep over all players on a pooled tick thread,

none of which coordinate with each other. All of these can independently satisfy `isMainThread()` and race on the same connection's `pendingActions` queue, reordering packets. This matches the reported symptom (DecentHolograms entity-spawn packet arriving after its metadata packet).

The reporter's own workaround (unconditionally synchronizing `flushQueue()`) is the right general shape; this PR keeps that approach but removes the now-inaccurate `isMainThread()`/`isPending` branching entirely, since neither branch is actually safe to leave unsynchronized under ShreddedPaper's threading model.

## Test plan

- [x] Builds cleanly (`./gradlew :shreddedpaper-server:compileJava`)
- [ ] Manual in-game verification with a plugin that depends on packet ordering (e.g. DecentHolograms, per the original report)