### PR TITLE
Fix missing volatile on ShreddedPaperConfiguration.instance

### DIFF
--- a/shreddedpaper-server/src/main/java/io/multipaper/shreddedpaper/config/ShreddedPaperConfiguration.java
+++ b/shreddedpaper-server/src/main/java/io/multipaper/shreddedpaper/config/ShreddedPaperConfiguration.java
@@ -15,7 +15,7 @@ public class ShreddedPaperConfiguration extends ConfigurationPart {
             Docs: https://github.com/MultiPaper/ShreddedPaper/blob/main/SHREDDEDPAPER_YAML.md\s
             """;
 
-    private static ShreddedPaperConfiguration instance;
+    private static volatile ShreddedPaperConfiguration instance;
 
     public static ShreddedPaperConfiguration get() {
         return instance;


### PR DESCRIPTION
## Summary

Found while investigating #49 (unrelated, reporting separately since it's a distinct bug).

`ShreddedPaperConfiguration.instance` is a plain `static` field. `get()` is read constantly from every region-tick-pool thread; `set()` is called from whatever thread runs `/reload` (not a region-tick thread). Without `volatile` there's no happens-before edge between a write and later reads on other threads, so per the JMM a tick thread is free to keep observing the pre-reload config object indefinitely, including after an operator flips a `multithreading`/`optimizations` setting via `/reload confirm`.

## Test plan

- [x] Builds cleanly (`./gradlew :shreddedpaper-server:compileJava`)