### PR TITLE
Isolate exceptions in processTrackQueueInParallel/flushQueueInParallel

### DIFF
--- a/shreddedpaper-server/src/main/java/io/multipaper/shreddedpaper/threading/ShreddedPaperChunkTicker.java
+++ b/shreddedpaper-server/src/main/java/io/multipaper/shreddedpaper/threading/ShreddedPaperChunkTicker.java
@@ -74,7 +74,11 @@ public class ShreddedPaperChunkTicker {
             }
 
             allFuture = allFuture.thenCompose(v -> CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)));
-            return allFuture;
+            return allFuture.exceptionally(e -> {
+                LOGGER.error("Exception processing tracked entities in parallel", e);
+                MinecraftServer.getServer().moonrise$setChunkSystemCrash(new RuntimeException("Ticking thread crash while processing tracked entities in parallel", e));
+                return null;
+            });
         } finally {
             allFuture.whenComplete((v, e) -> level.chunkScheduler.getRegionLocker().globalLock().tryUnlockWrite());
         }
@@ -89,7 +93,11 @@ public class ShreddedPaperChunkTicker {
             futures.add(CompletableFuture.runAsync(() -> players.forEach(player -> player.connection.connection.flushQueue()), ShreddedPaperTickThread.getExecutor()));
         }
 
-        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).exceptionally(e -> {
+            LOGGER.error("Exception flushing packet queues in parallel", e);
+            MinecraftServer.getServer().moonrise$setChunkSystemCrash(new RuntimeException("Ticking thread crash while flushing packet queues in parallel", e));
+            return null;
+        });
     }
 
     private CompletableFuture<Void> tickRegion(final ServerLevel level, final LevelChunkRegion region, final long timeInhabited, final List<MobCategory> filteredSpawningCategories, final NaturalSpawner.SpawnState spawnState) {


### PR DESCRIPTION
## Summary

Found while investigating #49 (unrelated, reporting separately since it's a distinct bug).

`tickRegion()` isolates any exception to the single failing region: it logs and calls `moonrise\$setChunkSystemCrash(...)`, letting the rest of the tick continue. `processTrackQueueInParallel()` and `flushQueueInParallel()`, one method away in the same file, have no `.exceptionally()` at all.

Traced the future chain up through `ServerChunkCache.tick()` -> `ServerLevel.tickAsync()` -> `MinecraftServer`'s per-level `future.join()` (unguarded by any try/catch at that point). An exception thrown here, e.g. from a plugin's buggy tracked-entity hook, or from flushing a broken connection, isn't silently dropped: it propagates uncaught through `join()` and crashes the entire tick loop, a much larger blast radius than the per-region isolation `tickRegion()` already provides.

This adds matching `.exceptionally()` handlers to both methods so a failure here degrades the same way `tickRegion()`'s does instead of taking the whole server down.

## Test plan

- [x] Builds cleanly (`./gradlew :shreddedpaper-server:compileJava`)