### PR TITLE
Fix server-crash when teleporting across regions with negative coordinates

### DIFF
--- a/shreddedpaper-server/minecraft-patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
+++ b/shreddedpaper-server/minecraft-patches/sources/net/minecraft/server/commands/TeleportCommand.java.patch
@@ -21,7 +21,7 @@
          float relativeOrAbsoluteYRot = relatives.contains(Relative.Y_ROT) ? yRot - victim.getYRot() : yRot;
          float relativeOrAbsoluteXRot = relatives.contains(Relative.X_ROT) ? xRot - victim.getXRot() : xRot;
          float newYRot = Mth.wrapDegrees(relativeOrAbsoluteYRot);
-+        ShreddedPaper.ensureSync(victim, level, ChunkPos.containing(new BlockPos((int) x, (int) y, (int) z)), () -> { // ShreddedPaper - run on correct thread
++        ShreddedPaper.ensureSync(victim, level, ChunkPos.containing(new BlockPos((int) Math.floor(x), (int) Math.floor(y), (int) Math.floor(z))), () -> { // ShreddedPaper - run on correct thread
          float newXRot = Mth.wrapDegrees(relativeOrAbsoluteXRot);
          if (victim.teleportTo(level, relativeOrAbsoluteX, relativeOrAbsoluteY, relativeOrAbsoluteZ, relatives, newYRot, newXRot, true, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND)) { // Paper - teleport cause
              if (lookAt != null) {


### PR DESCRIPTION
Found an issue where /tp can crash the server when teleporting across region boundaries with negative coordinates.

### Reproduction
With a region size of 8, run the following commands in sequence:
```
/tp @s 0 80 0
/tp @s 0 80 -128.5
```

### Cause
The crash occurs because region calculation uses an integer cast of the position. This works for positive coordinates but produces incorrect results for negative coordinates.

Using only the Z coordinate as an example (region size 8):
```
originLocation:  0      -> (int) 0     = region 0
targetLocation: -128.5  -> (int) -128  = region 0
```
``ensureSync()`` incorrectly determines that both positions are in the same region and executes the teleport on the current thread.
However, z = -128.5 actually belongs to region -1, not region 0. So the teleport runs on the wrong thread, crashing the server.

### Fix
This can be fixed by using eg. Math.floor() instead of relying on casting:
``Math.floor(-128.5) = -129 = region -1``
Now z=-128.5 correctly maps to region -1 and ensures that teleports across negative region boundaries are synchronized correctly.

Btw, really cool project